### PR TITLE
feat: rollback to cjs

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -1,18 +1,18 @@
-import esbuild from "esbuild";
-import peerDependencies from "./package.json" assert { type: "json" };
+const esbuild = require("esbuild");
+const { peerDependencies } = require("./package.json");
 
 esbuild
   .build({
     entryPoints: ["./src/index.ts"],
     bundle: true,
-    minify: false,
+    minify: true,
     sourcemap: false,
     target: "esnext",
     tsconfig: "./tsconfig.json",
     // Exclude the token.json
     external: ["./src/scripts/*", ...Object.keys(peerDependencies)],
-    format: "esm",
-    outfile: "./build/index.esm.js",
+    format: "cjs",
+    outfile: "./build/index.js",
     target: ["esnext", "node12"],
   })
   .catch(() => process.exit(1));

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "type": "module",
-  "main": "build/index.esm.js",
+  "main": "build/index.js",
   "types": "build/insex.d.ts",
   "scripts": {
     "ts-types": "tsc --emitDeclarationOnly --outDir build",


### PR DESCRIPTION
Because the TailwindCSS configuration file can only accept CommonJS, we have to expose the cjs file.
