### PR TITLE
fix: fix publish action token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,4 +45,4 @@ jobs:
 
       - uses: JS-DevTools/npm-publish@v1
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.NPMTOKEN }}


### PR DESCRIPTION
Because the npm token name in the publishing action is wrong. This commit fix the token name.
